### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,5 @@ storage/*.key
 Homestead.yaml
 Homestead.json
 
-# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
-.rocketeer/
-
 
 # End of https://www.gitignore.io/api/laravel


### PR DESCRIPTION
Descripción
Borramos rocketeer opción ya que no será utilizado- Para determinar los archivos en  .gitignore 


Cómo puedo probar los cambios
 
Archivos como el yaml y .env no se suben al repo ver archivo .gitignore completo